### PR TITLE
Update pyproject.toml example to monas 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.monas]
-packages = ["packages/"]
+packages = ["packages/*"]
 version = "0.0.2"
 python-version = "3.10"


### PR DESCRIPTION
the trailing "/*" is now mandatory